### PR TITLE
Add Zuul CI for container builds and functional tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,13 @@
+---
+- project:
+    name: openstack-k8s-operators/prometheus-podman-exporter
+    github-check:
+      jobs:
+        - telemetry-container-image-content-provider
+        - telemetry-openstack-meta-content-provider-master:
+            override-checkout: main
+        - functional-tests-osp18:
+            override-checkout: master
+            dependencies:
+              - telemetry-openstack-meta-content-provider-master
+              - telemetry-container-image-content-provider

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+IMG ?= quay.io/openstack-k8s-operators/prometheus-podman-exporter:latest
+
 PKG_PATH = "github.com/containers/prometheus-podman-exporter"
 BIN := ./bin
 GO := go
@@ -182,6 +184,14 @@ _HLP_TGTS_RX = '^[[:print:]]+:.*?\#\# .*$$'
 _HLP_TGTS_CMD = grep -E $(_HLP_TGTS_RX) $(MAKEFILE_LIST)
 _HLP_TGTS_LEN = $(shell $(_HLP_TGTS_CMD) | cut -d : -f 1 | wc -L)
 _HLPFMT = "%-$(_HLP_TGTS_LEN)s %s\n"
+.PHONY: docker-build
+docker-build: ## Build container image
+	podman build -t ${IMG} -f Containerfile .
+
+.PHONY: docker-push
+docker-push: ## Push container image
+	podman push ${IMG}
+
 .PHONY: help
 help: ## Print listing of key targets with their descriptions
 	@printf $(_HLPFMT) "Target:" "Description:"


### PR DESCRIPTION
Add a content-provider job that builds the prometheus-podman-exporter container image and runs it through the telemetry functional test pipeline. Add docker-build and docker-push Makefile targets matching the operator convention.

Generated-By: Claude-Code claude-opus-4-6
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/3856
Depends-On: https://github.com/infrawatch/feature-verification-tests/pull/345