### PR TITLE
Remove tj-actions/branch-names from build workflow

### DIFF
--- a/.github/workflows/build-prometheus-podman-exporter.yaml
+++ b/.github/workflows/build-prometheus-podman-exporter.yaml
@@ -33,14 +33,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v7
-
     - name: Set latest tag for non main branch
-      if: "${{ steps.branch-name.outputs.current_branch != 'main' }}"
+      if: github.ref_name != 'main'
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        latesttag=${{ steps.branch-name.outputs.current_branch }}-latest
+        latesttag=${BRANCH_NAME}-latest
         echo "latesttag=${latesttag@L}" >> $GITHUB_ENV
 
     - name: Buildah Action


### PR DESCRIPTION
Replace tj-actions/branch-names with github.ref_name which provides the branch name natively without a third-party action. The tj-actions GitHub namespace was compromised in March 2025 (CVE-2025-30066) and using actions from that namespace is no longer recommended. Pass the value via env: to avoid shell interpolation of untrusted input in run: blocks.

Generated-By: Claude Code

Jira: https://redhat.atlassian.net/browse/OSPRH-31969